### PR TITLE
Updating ose-multus-route-override-cni builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is used for building for OpenShift
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as rhel8
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS rhel8
 ADD . /usr/src/route-override
 WORKDIR /usr/src/route-override
 ENV CGO_ENABLED=0
@@ -8,7 +8,7 @@ ENV VERSION=rhel8 COMMIT=unset
 RUN ./build_linux.sh
 WORKDIR /
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.6 AS rhel7
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.7 AS rhel7
 ADD . /usr/src/route-override
 WORKDIR /usr/src/route-override
 ENV CGO_ENABLED=0
@@ -16,7 +16,7 @@ ENV GO111MODULE=off
 RUN ./build_linux.sh
 WORKDIR /
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 COPY --from=rhel7 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel7/bin/route-override
 COPY --from=rhel8 /usr/src/route-override/bin/route-override /usr/src/route-override/bin/route-override
 COPY --from=rhel8 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel8/bin/route-override


### PR DESCRIPTION
Updating ose-multus-route-override-cni builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-multus-route-override-cni.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
