### PR TITLE
Add rhel9 binary

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,13 @@
 # This dockerfile is used for building for OpenShift
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9
+ADD . /usr/src/route-override
+WORKDIR /usr/src/route-override
+ENV CGO_ENABLED=0
+ENV VERSION=rhel9 COMMIT=unset
+RUN ./build_linux.sh
+WORKDIR /
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel8
 ADD . /usr/src/route-override
 WORKDIR /usr/src/route-override
 ENV CGO_ENABLED=0
@@ -7,17 +15,10 @@ ENV VERSION=rhel8 COMMIT=unset
 RUN ./build_linux.sh
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS rhel7
-ADD . /usr/src/route-override
-WORKDIR /usr/src/route-override
-ENV CGO_ENABLED=0
-RUN ./build_linux.sh
-WORKDIR /
-
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.14
-COPY --from=rhel7 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel7/bin/route-override
-COPY --from=rhel8 /usr/src/route-override/bin/route-override /usr/src/route-override/bin/route-override
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.13
 COPY --from=rhel8 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel8/bin/route-override
+COPY --from=rhel9 /usr/src/route-override/bin/route-override /usr/src/route-override/bin/route-override
+COPY --from=rhel9 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel9/bin/route-override
 
 LABEL io.k8s.display-name="route override CNI" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a CNI plugin to override routes" \


### PR DESCRIPTION
Now that the binary is being dynamically compiled downstream, the binary must match the RHEL version of RHCOS because it is copied to the host.