### PR TITLE
[release-4.12] OCPBUGS-78160: hermetic 4.12

### DIFF
--- a/vendor/golang.org/x/text/encoding/internal/identifier/mib.go
+++ b/vendor/golang.org/x/text/encoding/internal/identifier/mib.go
@@ -538,8 +538,6 @@ const (
 	// ISO111ECMACyrillic is the MIB identifier with IANA name ECMA-cyrillic.
 	//
 	// ISO registry
-	// (formerly ECMA
-	// registry )
 	ISO111ECMACyrillic MIB = 77
 
 	// ISO121Canadian1 is the MIB identifier with IANA name CSA_Z243.4-1985-1.
@@ -732,18 +730,18 @@ const (
 
 	// ISO885913 is the MIB identifier with IANA name ISO-8859-13.
 	//
-	// ISO See http://www.iana.org/assignments/charset-reg/ISO-8859-13 http://www.iana.org/assignments/charset-reg/ISO-8859-13
+	// ISO See https://www.iana.org/assignments/charset-reg/ISO-8859-13 https://www.iana.org/assignments/charset-reg/ISO-8859-13
 	ISO885913 MIB = 109
 
 	// ISO885914 is the MIB identifier with IANA name ISO-8859-14.
 	//
-	// ISO See http://www.iana.org/assignments/charset-reg/ISO-8859-14
+	// ISO See https://www.iana.org/assignments/charset-reg/ISO-8859-14
 	ISO885914 MIB = 110
 
 	// ISO885915 is the MIB identifier with IANA name ISO-8859-15.
 	//
 	// ISO
-	// Please see: http://www.iana.org/assignments/charset-reg/ISO-8859-15
+	// Please see: https://www.iana.org/assignments/charset-reg/ISO-8859-15
 	ISO885915 MIB = 111
 
 	// ISO885916 is the MIB identifier with IANA name ISO-8859-16.
@@ -754,41 +752,41 @@ const (
 	// GBK is the MIB identifier with IANA name GBK.
 	//
 	// Chinese IT Standardization Technical Committee
-	// Please see: http://www.iana.org/assignments/charset-reg/GBK
+	// Please see: https://www.iana.org/assignments/charset-reg/GBK
 	GBK MIB = 113
 
 	// GB18030 is the MIB identifier with IANA name GB18030.
 	//
 	// Chinese IT Standardization Technical Committee
-	// Please see: http://www.iana.org/assignments/charset-reg/GB18030
+	// Please see: https://www.iana.org/assignments/charset-reg/GB18030
 	GB18030 MIB = 114
 
 	// OSDEBCDICDF0415 is the MIB identifier with IANA name OSD_EBCDIC_DF04_15.
 	//
 	// Fujitsu-Siemens standard mainframe EBCDIC encoding
-	// Please see: http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15
+	// Please see: https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-15
 	OSDEBCDICDF0415 MIB = 115
 
 	// OSDEBCDICDF03IRV is the MIB identifier with IANA name OSD_EBCDIC_DF03_IRV.
 	//
 	// Fujitsu-Siemens standard mainframe EBCDIC encoding
-	// Please see: http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV
+	// Please see: https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF03-IRV
 	OSDEBCDICDF03IRV MIB = 116
 
 	// OSDEBCDICDF041 is the MIB identifier with IANA name OSD_EBCDIC_DF04_1.
 	//
 	// Fujitsu-Siemens standard mainframe EBCDIC encoding
-	// Please see: http://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1
+	// Please see: https://www.iana.org/assignments/charset-reg/OSD-EBCDIC-DF04-1
 	OSDEBCDICDF041 MIB = 117
 
 	// ISO115481 is the MIB identifier with IANA name ISO-11548-1.
 	//
-	// See http://www.iana.org/assignments/charset-reg/ISO-11548-1
+	// See https://www.iana.org/assignments/charset-reg/ISO-11548-1
 	ISO115481 MIB = 118
 
 	// KZ1048 is the MIB identifier with IANA name KZ-1048.
 	//
-	// See http://www.iana.org/assignments/charset-reg/KZ-1048
+	// See https://www.iana.org/assignments/charset-reg/KZ-1048
 	KZ1048 MIB = 119
 
 	// Unicode is the MIB identifier with IANA name ISO-10646-UCS-2.
@@ -855,7 +853,7 @@ const (
 
 	// SCSU is the MIB identifier with IANA name SCSU.
 	//
-	// SCSU See http://www.iana.org/assignments/charset-reg/SCSU
+	// SCSU See https://www.iana.org/assignments/charset-reg/SCSU
 	SCSU MIB = 1011
 
 	// UTF7 is the MIB identifier with IANA name UTF-7.
@@ -884,22 +882,22 @@ const (
 
 	// CESU8 is the MIB identifier with IANA name CESU-8.
 	//
-	// https://www.unicode.org/unicode/reports/tr26
+	// https://www.unicode.org/reports/tr26
 	CESU8 MIB = 1016
 
 	// UTF32 is the MIB identifier with IANA name UTF-32.
 	//
-	// https://www.unicode.org/unicode/reports/tr19/
+	// https://www.unicode.org/reports/tr19/
 	UTF32 MIB = 1017
 
 	// UTF32BE is the MIB identifier with IANA name UTF-32BE.
 	//
-	// https://www.unicode.org/unicode/reports/tr19/
+	// https://www.unicode.org/reports/tr19/
 	UTF32BE MIB = 1018
 
 	// UTF32LE is the MIB identifier with IANA name UTF-32LE.
 	//
-	// https://www.unicode.org/unicode/reports/tr19/
+	// https://www.unicode.org/reports/tr19/
 	UTF32LE MIB = 1019
 
 	// BOCU1 is the MIB identifier with IANA name BOCU-1.
@@ -1461,152 +1459,152 @@ const (
 
 	// IBM00858 is the MIB identifier with IANA name IBM00858.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM00858
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM00858
 	IBM00858 MIB = 2089
 
 	// IBM00924 is the MIB identifier with IANA name IBM00924.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM00924
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM00924
 	IBM00924 MIB = 2090
 
 	// IBM01140 is the MIB identifier with IANA name IBM01140.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01140
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01140
 	IBM01140 MIB = 2091
 
 	// IBM01141 is the MIB identifier with IANA name IBM01141.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01141
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01141
 	IBM01141 MIB = 2092
 
 	// IBM01142 is the MIB identifier with IANA name IBM01142.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01142
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01142
 	IBM01142 MIB = 2093
 
 	// IBM01143 is the MIB identifier with IANA name IBM01143.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01143
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01143
 	IBM01143 MIB = 2094
 
 	// IBM01144 is the MIB identifier with IANA name IBM01144.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01144
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01144
 	IBM01144 MIB = 2095
 
 	// IBM01145 is the MIB identifier with IANA name IBM01145.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01145
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01145
 	IBM01145 MIB = 2096
 
 	// IBM01146 is the MIB identifier with IANA name IBM01146.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01146
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01146
 	IBM01146 MIB = 2097
 
 	// IBM01147 is the MIB identifier with IANA name IBM01147.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01147
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01147
 	IBM01147 MIB = 2098
 
 	// IBM01148 is the MIB identifier with IANA name IBM01148.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01148
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01148
 	IBM01148 MIB = 2099
 
 	// IBM01149 is the MIB identifier with IANA name IBM01149.
 	//
-	// IBM See http://www.iana.org/assignments/charset-reg/IBM01149
+	// IBM See https://www.iana.org/assignments/charset-reg/IBM01149
 	IBM01149 MIB = 2100
 
 	// Big5HKSCS is the MIB identifier with IANA name Big5-HKSCS.
 	//
-	// See http://www.iana.org/assignments/charset-reg/Big5-HKSCS
+	// See https://www.iana.org/assignments/charset-reg/Big5-HKSCS
 	Big5HKSCS MIB = 2101
 
 	// IBM1047 is the MIB identifier with IANA name IBM1047.
 	//
-	// IBM1047 (EBCDIC Latin 1/Open Systems) http://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf
+	// IBM1047 (EBCDIC Latin 1/Open Systems) https://www-1.ibm.com/servers/eserver/iseries/software/globalization/pdf/cp01047z.pdf
 	IBM1047 MIB = 2102
 
 	// PTCP154 is the MIB identifier with IANA name PTCP154.
 	//
-	// See http://www.iana.org/assignments/charset-reg/PTCP154
+	// See https://www.iana.org/assignments/charset-reg/PTCP154
 	PTCP154 MIB = 2103
 
 	// Amiga1251 is the MIB identifier with IANA name Amiga-1251.
 	//
-	// See http://www.amiga.ultranet.ru/Amiga-1251.html
+	// See https://www.amiga.ultranet.ru/Amiga-1251.html
 	Amiga1251 MIB = 2104
 
 	// KOI7switched is the MIB identifier with IANA name KOI7-switched.
 	//
-	// See http://www.iana.org/assignments/charset-reg/KOI7-switched
+	// See https://www.iana.org/assignments/charset-reg/KOI7-switched
 	KOI7switched MIB = 2105
 
 	// BRF is the MIB identifier with IANA name BRF.
 	//
-	// See http://www.iana.org/assignments/charset-reg/BRF
+	// See https://www.iana.org/assignments/charset-reg/BRF
 	BRF MIB = 2106
 
 	// TSCII is the MIB identifier with IANA name TSCII.
 	//
-	// See http://www.iana.org/assignments/charset-reg/TSCII
+	// See https://www.iana.org/assignments/charset-reg/TSCII
 	TSCII MIB = 2107
 
 	// CP51932 is the MIB identifier with IANA name CP51932.
 	//
-	// See http://www.iana.org/assignments/charset-reg/CP51932
+	// See https://www.iana.org/assignments/charset-reg/CP51932
 	CP51932 MIB = 2108
 
 	// Windows874 is the MIB identifier with IANA name windows-874.
 	//
-	// See http://www.iana.org/assignments/charset-reg/windows-874
+	// See https://www.iana.org/assignments/charset-reg/windows-874
 	Windows874 MIB = 2109
 
 	// Windows1250 is the MIB identifier with IANA name windows-1250.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1250
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1250
 	Windows1250 MIB = 2250
 
 	// Windows1251 is the MIB identifier with IANA name windows-1251.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1251
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1251
 	Windows1251 MIB = 2251
 
 	// Windows1252 is the MIB identifier with IANA name windows-1252.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1252
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1252
 	Windows1252 MIB = 2252
 
 	// Windows1253 is the MIB identifier with IANA name windows-1253.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1253
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1253
 	Windows1253 MIB = 2253
 
 	// Windows1254 is the MIB identifier with IANA name windows-1254.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1254
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1254
 	Windows1254 MIB = 2254
 
 	// Windows1255 is the MIB identifier with IANA name windows-1255.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1255
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1255
 	Windows1255 MIB = 2255
 
 	// Windows1256 is the MIB identifier with IANA name windows-1256.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1256
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1256
 	Windows1256 MIB = 2256
 
 	// Windows1257 is the MIB identifier with IANA name windows-1257.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1257
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1257
 	Windows1257 MIB = 2257
 
 	// Windows1258 is the MIB identifier with IANA name windows-1258.
 	//
-	// Microsoft http://www.iana.org/assignments/charset-reg/windows-1258
+	// Microsoft https://www.iana.org/assignments/charset-reg/windows-1258
 	Windows1258 MIB = 2258
 
 	// TIS620 is the MIB identifier with IANA name TIS-620.
@@ -1616,6 +1614,6 @@ const (
 
 	// CP50220 is the MIB identifier with IANA name CP50220.
 	//
-	// See http://www.iana.org/assignments/charset-reg/CP50220
+	// See https://www.iana.org/assignments/charset-reg/CP50220
 	CP50220 MIB = 2260
 )

--- a/vendor/golang.org/x/text/encoding/unicode/unicode.go
+++ b/vendor/golang.org/x/text/encoding/unicode/unicode.go
@@ -6,6 +6,7 @@
 package unicode // import "golang.org/x/text/encoding/unicode"
 
 import (
+	"bytes"
 	"errors"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -25,13 +26,93 @@ import (
 // the introduction of some kind of error type for conveying the erroneous code
 // point.
 
-// UTF8 is the UTF-8 encoding.
+// UTF8 is the UTF-8 encoding. It neither removes nor adds byte order marks.
 var UTF8 encoding.Encoding = utf8enc
+
+// UTF8BOM is an UTF-8 encoding where the decoder strips a leading byte order
+// mark while the encoder adds one.
+//
+// Some editors add a byte order mark as a signature to UTF-8 files. Although
+// the byte order mark is not useful for detecting byte order in UTF-8, it is
+// sometimes used as a convention to mark UTF-8-encoded files. This relies on
+// the observation that the UTF-8 byte order mark is either an illegal or at
+// least very unlikely sequence in any other character encoding.
+var UTF8BOM encoding.Encoding = utf8bomEncoding{}
+
+type utf8bomEncoding struct{}
+
+func (utf8bomEncoding) String() string {
+	return "UTF-8-BOM"
+}
+
+func (utf8bomEncoding) ID() (identifier.MIB, string) {
+	return identifier.Unofficial, "x-utf8bom"
+}
+
+func (utf8bomEncoding) NewEncoder() *encoding.Encoder {
+	return &encoding.Encoder{
+		Transformer: &utf8bomEncoder{t: runes.ReplaceIllFormed()},
+	}
+}
+
+func (utf8bomEncoding) NewDecoder() *encoding.Decoder {
+	return &encoding.Decoder{Transformer: &utf8bomDecoder{}}
+}
 
 var utf8enc = &internal.Encoding{
 	&internal.SimpleEncoding{utf8Decoder{}, runes.ReplaceIllFormed()},
 	"UTF-8",
 	identifier.UTF8,
+}
+
+type utf8bomDecoder struct {
+	checked bool
+}
+
+func (t *utf8bomDecoder) Reset() {
+	t.checked = false
+}
+
+func (t *utf8bomDecoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	if !t.checked {
+		if !atEOF && len(src) < len(utf8BOM) {
+			if len(src) == 0 {
+				return 0, 0, nil
+			}
+			return 0, 0, transform.ErrShortSrc
+		}
+		if bytes.HasPrefix(src, []byte(utf8BOM)) {
+			nSrc += len(utf8BOM)
+			src = src[len(utf8BOM):]
+		}
+		t.checked = true
+	}
+	nDst, n, err := utf8Decoder.Transform(utf8Decoder{}, dst[nDst:], src, atEOF)
+	nSrc += n
+	return nDst, nSrc, err
+}
+
+type utf8bomEncoder struct {
+	written bool
+	t       transform.Transformer
+}
+
+func (t *utf8bomEncoder) Reset() {
+	t.written = false
+	t.t.Reset()
+}
+
+func (t *utf8bomEncoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	if !t.written {
+		if len(dst) < len(utf8BOM) {
+			return nDst, 0, transform.ErrShortDst
+		}
+		nDst = copy(dst, utf8BOM)
+		t.written = true
+	}
+	n, nSrc, err := utf8Decoder.Transform(utf8Decoder{}, dst[nDst:], src, atEOF)
+	nDst += n
+	return nDst, nSrc, err
 }
 
 type utf8Decoder struct{ transform.NopResetter }
@@ -287,16 +368,13 @@ func (u *utf16Decoder) Reset() {
 }
 
 func (u *utf16Decoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	if len(src) < 2 && atEOF && u.current.bomPolicy&requireBOM != 0 {
+		return 0, 0, ErrMissingBOM
+	}
 	if len(src) == 0 {
-		if atEOF && u.current.bomPolicy&requireBOM != 0 {
-			return 0, 0, ErrMissingBOM
-		}
 		return 0, 0, nil
 	}
-	if u.current.bomPolicy&acceptBOM != 0 {
-		if len(src) < 2 {
-			return 0, 0, transform.ErrShortSrc
-		}
+	if len(src) >= 2 && u.current.bomPolicy&acceptBOM != 0 {
 		switch {
 		case src[0] == 0xfe && src[1] == 0xff:
 			u.current.endianness = BigEndian

--- a/vendor/golang.org/x/text/language/coverage.go
+++ b/vendor/golang.org/x/text/language/coverage.go
@@ -80,7 +80,7 @@ func (s allSubtags) Tags() []Tag {
 	return nil
 }
 
-// coverage is used used by NewCoverage which is used as a convenient way for
+// coverage is used by NewCoverage which is used as a convenient way for
 // creating Coverage implementations for partially defined data. Very often a
 // package will only need to define a subset of slices. coverage provides a
 // convenient way to do this. Moreover, packages using NewCoverage, instead of

--- a/vendor/golang.org/x/text/language/language.go
+++ b/vendor/golang.org/x/text/language/language.go
@@ -335,6 +335,11 @@ func (t Tag) Variants() []Variant {
 // Parent returns the CLDR parent of t. In CLDR, missing fields in data for a
 // specific language are substituted with fields from the parent language.
 // The parent for a language may change for newer versions of CLDR.
+//
+// Parent returns a tag for a less specific language that is mutually
+// intelligible or Und if there is no such language. This may not be the same as
+// simply stripping the last BCP 47 subtag. For instance, the parent of "zh-TW"
+// is "zh-Hant", and the parent of "zh-Hant" is "und".
 func (t Tag) Parent() Tag {
 	return Tag(compact.Tag(t).Parent())
 }
@@ -525,7 +530,7 @@ func (r Region) String() string {
 // Note that not all regions have a 3-letter ISO code.
 // In such cases this method returns "ZZZ".
 func (r Region) ISO3() string {
-	return r.regionID.String()
+	return r.regionID.ISO3()
 }
 
 // M49 returns the UN M.49 encoding of r, or 0 if this encoding

--- a/vendor/golang.org/x/text/language/parse.go
+++ b/vendor/golang.org/x/text/language/parse.go
@@ -41,7 +41,7 @@ func Parse(s string) (t Tag, err error) {
 // value. All other values are preserved. It accepts tags in the BCP 47 format
 // and extensions to this standard defined in
 // https://www.unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers.
-// The resulting tag is canonicalized using the the canonicalization type c.
+// The resulting tag is canonicalized using the canonicalization type c.
 func (c CanonType) Parse(s string) (t Tag, err error) {
 	tt, err := language.Parse(s)
 	if err != nil {
@@ -199,7 +199,7 @@ func split(s string, c byte) (head, tail string) {
 	return strings.TrimSpace(s), ""
 }
 
-// Add hack mapping to deal with a small number of cases that that occur
+// Add hack mapping to deal with a small number of cases that occur
 // in Accept-Language (with reasonable frequency).
 var acceptFallback = map[string]language.Language{
 	"english": _en,

--- a/vendor/golang.org/x/text/transform/transform.go
+++ b/vendor/golang.org/x/text/transform/transform.go
@@ -78,8 +78,8 @@ type SpanningTransformer interface {
 	// considering the error err.
 	//
 	// A nil error means that all input bytes are known to be identical to the
-	// output produced by the Transformer. A nil error can be be returned
-	// regardless of whether atEOF is true. If err is nil, then then n must
+	// output produced by the Transformer. A nil error can be returned
+	// regardless of whether atEOF is true. If err is nil, then n must
 	// equal len(src); the converse is not necessarily true.
 	//
 	// ErrEndOfSpan means that the Transformer output may differ from the
@@ -493,7 +493,7 @@ func (c *chain) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err erro
 	return dstL.n, srcL.p, err
 }
 
-// Deprecated: use runes.Remove instead.
+// Deprecated: Use runes.Remove instead.
 func RemoveFunc(f func(r rune) bool) Transformer {
 	return removeF(f)
 }
@@ -648,7 +648,8 @@ func String(t Transformer, s string) (result string, n int, err error) {
 	// Transform the remaining input, growing dst and src buffers as necessary.
 	for {
 		n := copy(src, s[pSrc:])
-		nDst, nSrc, err := t.Transform(dst[pDst:], src[:n], pSrc+n == len(s))
+		atEOF := pSrc+n == len(s)
+		nDst, nSrc, err := t.Transform(dst[pDst:], src[:n], atEOF)
 		pDst += nDst
 		pSrc += nSrc
 
@@ -659,6 +660,9 @@ func String(t Transformer, s string) (result string, n int, err error) {
 				dst = grow(dst, pDst)
 			}
 		} else if err == ErrShortSrc {
+			if atEOF {
+				return string(dst[:pDst]), pSrc, err
+			}
 			if nSrc == 0 {
 				src = grow(src, 0)
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ golang.org/x/net/html/atom
 golang.org/x/net/html/charset
 # golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f
 golang.org/x/sys/unix
-# golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
+# golang.org/x/text v0.3.3
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex


### PR DESCRIPTION
ART can't build ose-multus-route-override-cni hermetically

The error is the following:

```
Error: PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
  Please try running `go mod vendor` and committing the changes.
  Note that you may need to `git add --force` ignored files in the vendor/ dir.
```