### PR TITLE
OCPBUGS-83863: Remove rhel8 build stage

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -7,18 +7,8 @@ ENV VERSION=rhel9 COMMIT=unset
 RUN ./build_linux.sh
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.21 AS rhel8
-ADD . /usr/src/route-override
-WORKDIR /usr/src/route-override
-ENV CGO_ENABLED=0
-ENV VERSION=rhel8 COMMIT=unset
-RUN ./build_linux.sh
-WORKDIR /
-
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
-COPY --from=rhel8 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel8/bin/route-override
 COPY --from=rhel9 /usr/src/route-override/bin/route-override /usr/src/route-override/bin/route-override
-COPY --from=rhel9 /usr/src/route-override/bin/route-override /usr/src/route-override/rhel9/bin/route-override
 
 LABEL io.k8s.display-name="route override CNI" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a CNI plugin to override routes" \


### PR DESCRIPTION
Remove the rhel8 build stage

The rhel9/rhel10 version-specific subdirectories are no longer needed
since openshift/cluster-network-operator#2967 removed the OS detection
logic and now copies binaries directly from the base directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Build infrastructure updated exclusively to RHEL9
  * Linux plugin binaries optimized to reduce size and improve efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->