### PR TITLE
[WIP] Add ECMP route support

### DIFF
--- a/cmd/route-override/route-override.go
+++ b/cmd/route-override/route-override.go
@@ -38,17 +38,42 @@ import (
 // + only checko route/dst
 //go build ./cmd/route-override/
 
+// ECMPRoute represents a multipath route with multiple gateways
+type ECMPRoute struct {
+	Dst net.IPNet
+	GWs []net.IP
+}
+
+func (r *ECMPRoute) UnmarshalJSON(data []byte) error {
+	v := struct {
+		Dst string   `json:"dst"`
+		GWs []net.IP `json:"gws"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	_, dst, err := net.ParseCIDR(v.Dst)
+	if err != nil {
+		return fmt.Errorf("ecmproute: invalid dst %q: %v", v.Dst, err)
+	}
+	r.Dst = *dst
+	r.GWs = v.GWs
+	return nil
+}
+
 // RouteOverrideConfig represents the network route-override configuration
 type RouteOverrideConfig struct {
 	types.NetConf
 
 	PrevResult *current.Result `json:"-"`
 
-	FlushRoutes  bool           `json:"flushroutes,omitempty"`
-	FlushGateway bool           `json:"flushgateway,omitempty"`
-	DelRoutes    []*types.Route `json:"delroutes"`
-	AddRoutes    []*types.Route `json:"addroutes"`
-	SkipCheck    bool           `json:"skipcheck,omitempty"`
+	FlushRoutes   bool           `json:"flushroutes,omitempty"`
+	FlushGateway  bool           `json:"flushgateway,omitempty"`
+	DelRoutes     []*types.Route `json:"delroutes"`
+	AddRoutes     []*types.Route `json:"addroutes"`
+	DelECMPRoutes []*ECMPRoute   `json:"delecmproutes,omitempty"`
+	AddECMPRoutes []*ECMPRoute   `json:"addecmproutes,omitempty"`
+	SkipCheck     bool           `json:"skipcheck,omitempty"`
 
 	Args *struct {
 		A *IPAMArgs `json:"cni"`
@@ -57,11 +82,13 @@ type RouteOverrideConfig struct {
 
 // IPAMArgs represents CNI argument conventions for the plugin
 type IPAMArgs struct {
-	FlushRoutes  *bool          `json:"flushroutes,omitempty"`
-	FlushGateway *bool          `json:"flushgateway,omitempty"`
-	DelRoutes    []*types.Route `json:"delroutes,omitempty"`
-	AddRoutes    []*types.Route `json:"addroutes,omitempty"`
-	SkipCheck    *bool          `json:"skipcheck,omitempty"`
+	FlushRoutes   *bool          `json:"flushroutes,omitempty"`
+	FlushGateway  *bool          `json:"flushgateway,omitempty"`
+	DelRoutes     []*types.Route `json:"delroutes,omitempty"`
+	AddRoutes     []*types.Route `json:"addroutes,omitempty"`
+	DelECMPRoutes []*ECMPRoute   `json:"delecmproutes,omitempty"`
+	AddECMPRoutes []*ECMPRoute   `json:"addecmproutes,omitempty"`
+	SkipCheck     *bool          `json:"skipcheck,omitempty"`
 }
 
 /*
@@ -96,6 +123,14 @@ func parseConf(data []byte, envArgs string) (*RouteOverrideConfig, error) {
 
 		if conf.Args.A.SkipCheck != nil {
 			conf.SkipCheck = *conf.Args.A.SkipCheck
+		}
+
+		if conf.Args.A.DelECMPRoutes != nil {
+			conf.DelECMPRoutes = conf.Args.A.DelECMPRoutes
+		}
+
+		if conf.Args.A.AddECMPRoutes != nil {
+			conf.AddECMPRoutes = conf.Args.A.AddECMPRoutes
 		}
 
 	}
@@ -215,6 +250,48 @@ func addRoute(dev netlink.Link, route *types.Route) error {
 	})
 }
 
+func addECMPRoute(dev netlink.Link, route *ECMPRoute) error {
+	if len(route.GWs) == 0 {
+		return fmt.Errorf("addecmproutes: gws must not be empty")
+	}
+	nexthops := make([]*netlink.NexthopInfo, 0, len(route.GWs))
+	for _, gw := range route.GWs {
+		routes, err := netlink.RouteGet(gw)
+		if err != nil || len(routes) == 0 {
+			return fmt.Errorf("addecmproutes: cannot resolve interface for gw %v: %v", gw, err)
+		}
+		if routes[0].LinkIndex != dev.Attrs().Index {
+			return fmt.Errorf("addecmproutes: gw %v is not reachable via %s", gw, dev.Attrs().Name)
+		}
+		nexthops = append(nexthops, &netlink.NexthopInfo{
+			LinkIndex: routes[0].LinkIndex,
+			Gw:        gw,
+		})
+	}
+	return netlink.RouteAdd(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		Dst:       &route.Dst,
+		MultiPath: nexthops,
+	})
+}
+
+func deleteECMPRoute(route *ECMPRoute) error {
+	family := netlink.FAMILY_V4
+	if route.Dst.IP.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
+	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Dst: &route.Dst}, netlink.RT_FILTER_DST)
+	if err != nil {
+		return err
+	}
+	for _, r := range routes {
+		if err := netlink.RouteDel(&r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func processRoutes(netnsname string, conf *RouteOverrideConfig) (*current.Result, error) {
 	netns, err := ns.GetNS(netnsname)
 	if err != nil {
@@ -285,6 +362,20 @@ func processRoutes(netnsname string, conf *RouteOverrideConfig) (*current.Result
 			newRoutes = append(newRoutes, route)
 			if err := addRoute(dev, route); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to add route: %v: %v", route, err)
+			}
+		}
+
+		// Delete ECMP routes
+		for _, route := range conf.DelECMPRoutes {
+			if err := deleteECMPRoute(route); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to delete ECMP route %v: %v", route, err)
+			}
+		}
+
+		// Add ECMP routes
+		for _, route := range conf.AddECMPRoutes {
+			if err := addECMPRoute(dev, route); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to add ECMP route: %v: %v", route, err)
 			}
 		}
 

--- a/cmd/route-override/route-override_test.go
+++ b/cmd/route-override/route-override_test.go
@@ -72,6 +72,34 @@ func testHasRoute(routes []netlink.Route, dst *net.IPNet) bool {
 	return false
 }
 
+func testAddECMPRoute(link netlink.Link, dst *net.IPNet, gws []net.IP) error {
+	nexthops := make([]*netlink.NexthopInfo, 0, len(gws))
+	for _, gw := range gws {
+		nexthops = append(nexthops, &netlink.NexthopInfo{
+			LinkIndex: link.Attrs().Index,
+			Gw:        gw,
+			Hops:      0,
+		})
+	}
+	return netlink.RouteAdd(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		Dst:       dst,
+		MultiPath: nexthops,
+	})
+}
+
+func testGetECMPNexthops(dst *net.IPNet) int {
+	family := netlink.FAMILY_V4
+	if dst.IP.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
+	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Dst: dst}, netlink.RT_FILTER_DST)
+	if err != nil || len(routes) == 0 {
+		return 0
+	}
+	return len(routes[0].MultiPath)
+}
+
 var _ = Describe("route-override operations by conf, cniVersion:0.4.0", func() {
 	const IFNAME string = "dummy0"
 	var originalNS ns.NetNS
@@ -2291,6 +2319,219 @@ var _ = Describe("route-override operations by args", func() {
 				Expect(testHasRoute(routes, route1)).To(Equal(true))
 				Expect(testHasRoute(routes, nil)).To(Equal(true))
 
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("route-override ECMP operations", func() {
+	const IFNAME string = "dummy0"
+
+	var originalNS ns.NetNS
+	var targetNS ns.NetNS
+
+	BeforeEach(func() {
+		var err error
+		originalNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		targetNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = targetNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{Name: IFNAME},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(originalNS.Close()).To(Succeed())
+	})
+
+	Context("IPv4 ECMP route manipulation", func() {
+		It("check addecmproutes creates ECMP route with multiple gateways", func() {
+			conf := []byte(`{
+				"name": "test",
+				"type": "route-override",
+				"cniVersion": "0.3.1",
+				"addecmproutes": [
+				{
+					"dst": "20.0.0.0/24",
+					"gws": ["10.0.0.1", "10.0.0.254"]
+				}],
+				"prevResult": {
+					"cniVersion": "0.3.1",
+					"interfaces": [{"name": "dummy0", "sandbox":"netns"}],
+					"ips": [{"version": "4", "address": "10.0.0.2/24", "gateway": "10.0.0.1", "interface": 0}],
+					"routes": [{"dst": "0.0.0.0/0", "gw": "10.0.0.1"}]
+				}
+			}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+				err = testAddRoute(link, net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0), net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, ecmpDst, _ := net.ParseCIDR("20.0.0.0/24")
+				Expect(testGetECMPNexthops(ecmpDst)).To(Equal(2))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("check delecmproutes removes ECMP route", func() {
+			conf := []byte(`{
+				"name": "test",
+				"type": "route-override",
+				"cniVersion": "0.3.1",
+				"delecmproutes": [
+				{
+					"dst": "20.0.0.0/24"
+				}],
+				"prevResult": {
+					"cniVersion": "0.3.1",
+					"interfaces": [{"name": "dummy0", "sandbox":"netns"}],
+					"ips": [{"version": "4", "address": "10.0.0.2/24", "gateway": "10.0.0.1", "interface": 0}],
+					"routes": [{"dst": "0.0.0.0/0", "gw": "10.0.0.1"}]
+				}
+			}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+				err = testAddAddr(link, net.IPv4(10, 0, 0, 2), net.CIDRMask(24, 32))
+				Expect(err).NotTo(HaveOccurred())
+				err = testAddRoute(link, net.IPv4(0, 0, 0, 0), net.CIDRMask(0, 0), net.IPv4(10, 0, 0, 1))
+				Expect(err).NotTo(HaveOccurred())
+
+				_, ecmpDst, _ := net.ParseCIDR("20.0.0.0/24")
+				err = testAddECMPRoute(link, ecmpDst, []net.IP{net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 254)})
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, ecmpDst, _ := net.ParseCIDR("20.0.0.0/24")
+				Expect(testGetECMPNexthops(ecmpDst)).To(Equal(0))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("IPv6 ECMP route manipulation", func() {
+		It("check addecmproutes creates IPv6 ECMP route", func() {
+			conf := []byte(`{
+				"name": "test",
+				"type": "route-override",
+				"cniVersion": "0.3.1",
+				"addecmproutes": [
+				{
+					"dst": "2001:DB8:2::/64",
+					"gws": ["2001:DB8:1::1", "2001:DB8:1::ffff"]
+				}],
+				"prevResult": {
+					"cniVersion": "0.3.1",
+					"interfaces": [{"name": "dummy0", "sandbox":"netns"}],
+					"ips": [{"version": "6", "address": "2001:DB8:1::2/64", "gateway": "2001:DB8:1::1", "interface": 0}],
+					"routes": [{"dst": "::/0"}]
+				}
+			}`)
+
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       targetNS.Path(),
+				IfName:      IFNAME,
+				StdinData:   conf,
+			}
+
+			err := targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				link, err := netlink.LinkByName(IFNAME)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkSetUp(link)
+				Expect(err).NotTo(HaveOccurred())
+				err = testAddAddr(link, net.ParseIP("2001:DB8:1::2"), net.CIDRMask(64, 128))
+				Expect(err).NotTo(HaveOccurred())
+				err = testAddRoute(link, net.ParseIP("::"), net.CIDRMask(0, 0), net.ParseIP("2001:DB8:1::1"))
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = originalNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = targetNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, ecmpDst, _ := net.ParseCIDR("2001:DB8:2::/64")
+				Expect(testGetECMPNexthops(ecmpDst)).To(Equal(2))
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This is a reference implementation for https://github.com/openshift/route-override-cni/issues/68.
(I created this PR as a starting point for discussion.)
The text in this section will be updated once the specification and implementation are finalized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ECMP (multipath) route override support.
  * Support for configuring multiple gateways per destination and for applying or removing ECMP routes via configuration.

* **Tests**
  * Added IPv4 and IPv6 tests validating installation and removal of ECMP multipath routes (verifying multiple nexthops).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->