### PR TITLE
feat: option to use prevResult for default gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ kubectl create -f deployments/daemonset-install.yaml
 * `delroutes`: (object, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 * `addroutes`: (object, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 * `skipcheck`: (bool, optional): true if you want to skip CNI's check command. Please set true if you will change routes after its launch
+* `gwprevresult`: (bool, optional): true if you want to use `PrevResult.IPs[0].Gateway` (if set) as the default value for AddRoutes which do not have "gw" defined
 
 ## Process Sequence
 
@@ -78,4 +79,4 @@ The following [args conventions](https://github.com/containernetworking/cni/blob
 * `flushgateway`: (bool, optional): true if you flush default route (gateway).
 * `delroutes`: (object, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 * `addroutes`: (object, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
-
+* `gwprevresult`: (bool, optional): true if you want to use `PrevResult.IPs[0].Gateway` (if set) as the default value for AddRoutes which do not have "gw" defined

--- a/cmd/route-override/route-override.go
+++ b/cmd/route-override/route-override.go
@@ -44,11 +44,12 @@ type RouteOverrideConfig struct {
 
 	PrevResult *current.Result `json:"-"`
 
-	FlushRoutes  bool           `json:"flushroutes,omitempty"`
-	FlushGateway bool           `json:"flushgateway,omitempty"`
-	DelRoutes    []*types.Route `json:"delroutes"`
-	AddRoutes    []*types.Route `json:"addroutes"`
-	SkipCheck    bool           `json:"skipcheck,omitempty"`
+	FlushRoutes                  bool           `json:"flushroutes,omitempty"`
+	FlushGateway                 bool           `json:"flushgateway,omitempty"`
+	DelRoutes                    []*types.Route `json:"delroutes"`
+	AddRoutes                    []*types.Route `json:"addroutes"`
+	SkipCheck                    bool           `json:"skipcheck,omitempty"`
+	DefaultGatewayFromPrevResult bool           `json:"gwprevresult,omitempty"`
 
 	Args *struct {
 		A *IPAMArgs `json:"cni"`
@@ -57,11 +58,12 @@ type RouteOverrideConfig struct {
 
 // IPAMArgs represents CNI argument conventions for the plugin
 type IPAMArgs struct {
-	FlushRoutes  *bool          `json:"flushroutes,omitempty"`
-	FlushGateway *bool          `json:"flushgateway,omitempty"`
-	DelRoutes    []*types.Route `json:"delroutes,omitempty"`
-	AddRoutes    []*types.Route `json:"addroutes,omitempty"`
-	SkipCheck    *bool          `json:"skipcheck,omitempty"`
+	FlushRoutes                  *bool          `json:"flushroutes,omitempty"`
+	FlushGateway                 *bool          `json:"flushgateway,omitempty"`
+	DelRoutes                    []*types.Route `json:"delroutes,omitempty"`
+	AddRoutes                    []*types.Route `json:"addroutes,omitempty"`
+	SkipCheck                    *bool          `json:"skipcheck,omitempty"`
+	DefaultGatewayFromPrevResult *bool          `json:"gwprevresult,omitempty"`
 }
 
 /*
@@ -96,6 +98,10 @@ func parseConf(data []byte, envArgs string) (*RouteOverrideConfig, error) {
 
 		if conf.Args.A.SkipCheck != nil {
 			conf.SkipCheck = *conf.Args.A.SkipCheck
+		}
+
+		if conf.Args.A.DefaultGatewayFromPrevResult != nil {
+			conf.DefaultGatewayFromPrevResult = *conf.Args.A.DefaultGatewayFromPrevResult
 		}
 
 	}
@@ -282,6 +288,11 @@ func processRoutes(netnsname string, conf *RouteOverrideConfig) (*current.Result
 		// Add route
 		dev, _ := netlink.LinkByName(containerIFName)
 		for _, route := range conf.AddRoutes {
+			if conf.DefaultGatewayFromPrevResult && len(route.GW) == 0 {
+				if len(conf.PrevResult.IPs) > 0 {
+					route.GW = conf.PrevResult.IPs[0].Gateway
+				}
+			}
 			newRoutes = append(newRoutes, route)
 			if err := addRoute(dev, route); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to add route: %v: %v", route, err)


### PR DESCRIPTION
If `--gwprevresult` or `{"gwprevresult": true}`, use `PrevResult.IPs[0].Gateway` as the default value for any `addroute` definitions which do not have `gw` set.

This is just a proposal to try to close this longstanding issue. I am very open to other ideas for implementation, or alternative designs. One option is to change this to an integer (`defaultgatewayindex`) where, if set, it will use the gateway at that specified index instead, rather than always using index 0.

If anyone has tips for testing this (the harnesses seem to reimplement the actual calls instead of calling them for real, which might just mean I need to add this logic to `testAddRoute`), I'd love to get some test cases written.

No AI was used to create this PR.

Fixes: #50

I also noticed that the docs state:

>`addroutes`: (object, optional): list of routes add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.

From everything I see in the code, I do not believe this is actually true, and I'm happy to fix that documentation issue in the PR or a subsequent one.